### PR TITLE
Fix player sprite mirroring and the cane hitbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,14 +611,19 @@ const WAVES = [
 function drawPixelChar(x, y, facing) {
   ctx.save();
   ctx.translate(x, y);
-  
+  // Mirror the whole sprite in one go. Negating individual x offsets does NOT
+  // mirror a rect — it moves the anchor while the rect still extends rightward,
+  // so facing left threw the 20px-wide hair block clear of the head (which had
+  // no facing term at all) and left it floating off to the right.
+  ctx.scale(facing, 1);
+
   // Body - grumpy old programmer
   // Hair (gray, wild)
   ctx.fillStyle = '#c0c0c0';
-  ctx.fillRect(-10 * facing, -18, 20, 6);
-  ctx.fillRect(-12 * facing, -16, 4, 4);
-  ctx.fillRect(8 * facing, -16, 4, 4);
-  
+  ctx.fillRect(-10, -18, 20, 6);
+  ctx.fillRect(-12, -16, 4, 4);
+  ctx.fillRect(8, -16, 4, 4);
+
   // Head
   ctx.fillStyle = '#ffd5b4';
   ctx.fillRect(-8, -14, 16, 14);
@@ -659,8 +664,10 @@ function drawPixelChar(x, y, facing) {
   // Cane
   if (caneSwinging) {
     ctx.save();
-    ctx.translate(6 * facing, 4);
-    ctx.rotate(caneAngle * facing);
+    // Under the mirror the rotation flips with everything else, so no
+    // per-facing terms are needed here either.
+    ctx.translate(6, 4);
+    ctx.rotate(caneAngle);
     ctx.fillStyle = '#8B4513';
     ctx.fillRect(0, -2, 30, 3);
     ctx.fillStyle = '#D2691E';
@@ -675,9 +682,9 @@ function drawPixelChar(x, y, facing) {
   } else {
     // Cane at rest
     ctx.fillStyle = '#8B4513';
-    ctx.fillRect(8 * facing, 2, 3, 26);
+    ctx.fillRect(8, 2, 3, 26);
     ctx.fillStyle = '#D2691E';
-    ctx.fillRect(6 * facing, 0, 7, 4);
+    ctx.fillRect(6, 0, 7, 4);
   }
   
   ctx.restore();
@@ -1062,8 +1069,43 @@ function addText(x, y, text, life, color) {
   floatingTexts.push({ x, y, text, life, maxLife: life, color });
 }
 
+// The cane sweeps an arc in FRONT of the player, plus a bubble centred ON him
+// so anything already in your face still gets smacked. The old test was a
+// circle centred 40px ahead with radius 30, which covered 10-70px forward and
+// left a dead zone over the player's own body — precisely where enemies end up,
+// because every one of them homes straight in on you. You could be surrounded
+// and swing through all of it.
+// 72/92 rather than something tighter so the new arc strictly contains the old
+// hitbox: the old circle reached 70px forward (90 in rage), and nobody should
+// lose a poke they used to land.
+const CANE_RANGE = 72;
+const CANE_RANGE_RAGE = 92;
+const CANE_CLOSE = 30;   // hits regardless of which way you're facing
+const CANE_ACTIVE_FROM = 4;
+const CANE_ACTIVE_TO = 9;
+
+function caneRange() {
+  return activePowerup === 'rage' ? CANE_RANGE_RAGE : CANE_RANGE;
+}
+
+// Melee assist: if the nearest thing in reach is behind you, turn into it.
+// On touch, facing only changes when the stick is pushed sideways, so being
+// chased from behind while walking up was unwinnable.
+function faceNearestTarget() {
+  let best = null, bestDist = Infinity;
+  for (const enemy of enemies) {
+    if (enemy.hp <= 0) continue;
+    const d = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+    if (d < bestDist) { bestDist = d; best = enemy; }
+  }
+  if (!best || bestDist > caneRange()) return;
+  const dx = best.x - player.x;
+  if (dx * player.facing < 0 && Math.abs(dx) > 6) player.facing = dx > 0 ? 1 : -1;
+}
+
 function swingCane() {
   if (!caneSwinging && gameRunning) {
+    faceNearestTarget();
     caneSwinging = true;
     caneAngle = -1.5;
     caneTimer = 0;
@@ -1072,18 +1114,19 @@ function swingCane() {
 
 function checkCaneHit() {
   if (!caneSwinging) return;
-  
-  const caneReach = 40;
-  const caneX = player.x + player.facing * caneReach;
-  const caneY = player.y;
-  const hitRadius = activePowerup === 'rage' ? 50 : 30;
-  
+
+  const range = caneRange();
+
   enemies.forEach(enemy => {
-    const dx = enemy.x - caneX;
-    const dy = enemy.y - caneY;
+    const dx = enemy.x - player.x;
+    const dy = enemy.y - (player.y + 4);
     const dist = Math.sqrt(dx * dx + dy * dy);
-    
-    if (dist < hitRadius && enemy.hit <= 0) {
+
+    // Forward half-disc, or close enough that facing shouldn't matter.
+    const reaches = dist < range &&
+      (dx * player.facing > -8 || dist < CANE_CLOSE);
+
+    if (reaches && enemy.hit <= 0) {
       const damage = activePowerup === 'rage' ? 3 : 1;
       enemy.hp -= damage;
       enemy.hit = 15;
@@ -1156,7 +1199,10 @@ function update() {
   if (caneSwinging) {
     caneTimer++;
     caneAngle += 0.25;
-    if (caneTimer === 6) checkCaneHit();
+    // Live for several frames rather than one. At 60fps a single-frame test was
+    // a 16ms window, so a Dan's Fix at speed 3 could cross the whole arc between
+    // checks. enemy.hit gates repeats, so this can't double-hit within a swing.
+    if (caneTimer >= CANE_ACTIVE_FROM && caneTimer <= CANE_ACTIVE_TO) checkCaneHit();
     if (caneTimer > 12) { caneSwinging = false; caneAngle = 0; }
   }
   
@@ -1373,6 +1419,23 @@ function draw() {
   // Draw enemies
   enemies.forEach(drawEnemy);
   
+  // Swing arc — shows exactly what the cane covers, while it covers it, so the
+  // hitbox is something you can read instead of something you infer from deaths.
+  if (caneSwinging && caneTimer >= CANE_ACTIVE_FROM && caneTimer <= CANE_ACTIVE_TO) {
+    const range = caneRange();
+    const fade = 1 - (caneTimer - CANE_ACTIVE_FROM) / (CANE_ACTIVE_TO - CANE_ACTIVE_FROM + 1);
+    const start = player.facing === 1 ? -Math.PI / 2 : Math.PI / 2;
+    ctx.save();
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = activePowerup === 'rage'
+      ? `rgba(255, 65, 54, ${0.15 + fade * 0.45})`
+      : `rgba(255, 220, 0, ${0.12 + fade * 0.33})`;
+    ctx.beginPath();
+    ctx.arc(player.x, player.y + 4, range - 4, start, start + Math.PI);
+    ctx.stroke();
+    ctx.restore();
+  }
+
   // Draw player
   drawPixelChar(player.x, player.y, player.facing);
   

--- a/test_fixes.mjs
+++ b/test_fixes.mjs
@@ -281,6 +281,39 @@ console.log('\n#20: Dead code removed / put to use');
   assert(html.includes('player.walkFrame]'), 'walkFrame is actually used when drawing legs');
 }
 
+// ---- TEST #21: sprite mirroring ----
+console.log('\n#21: Player sprite mirrors as a whole');
+{
+  const fn = html.substring(html.indexOf('function drawPixelChar'), html.indexOf('function drawEnemy'));
+  assert(fn.includes('ctx.scale(facing, 1)'), 'drawPixelChar mirrors via ctx.scale');
+  // Negating an x offset moves a rect's anchor without mirroring it, which is
+  // what detached the hair from the head when facing left.
+  assert(!/fillRect\(\s*-?\d+(\.\d+)?\s*\*\s*facing/.test(fn),
+    'No fillRect anchored on a negated facing offset');
+  assert(!stripComments(fn).includes('* facing'),
+    'No per-part facing multipliers left in the sprite');
+}
+
+// ---- TEST #22: cane arc ----
+console.log('\n#22: Cane hitbox is an arc around the player');
+{
+  assert(html.includes('const CANE_RANGE ='), 'Cane range is a named constant');
+  assert(html.includes('const CANE_CLOSE ='), 'Close-range bubble is a named constant');
+  const fn = html.substring(html.indexOf('function checkCaneHit'), html.indexOf('function update()'));
+  assert(!fn.includes('const caneX'),
+    'Hit test no longer uses a circle offset ahead of the player (left a dead zone on his own body)');
+  assert(fn.includes('enemy.x - player.x') && fn.includes('player.y'),
+    'Hit test measures from the player');
+  assert(fn.includes('dx * player.facing'), 'Hit test uses a forward half-disc');
+  assert(fn.includes('CANE_CLOSE'), 'Close range ignores facing');
+  assert(html.includes('function faceNearestTarget'), 'Swinging can turn you toward a target behind');
+  assert(html.includes('CANE_ACTIVE_FROM') && html.includes('CANE_ACTIVE_TO'),
+    'Swing is live across a frame window, not a single frame');
+  assert(!html.includes('if (caneTimer === 6) checkCaneHit()'), 'Single-frame hit check removed');
+  const drawFn = html.substring(html.indexOf('function draw()'));
+  assert(drawFn.includes('Swing arc'), 'The arc is drawn so the hitbox is visible');
+}
+
 // ---- SUMMARY ----
 console.log(`\n=== RESULTS: ${passed} passed, ${failed} failed ===`);
 if (failed === 0) console.log('ALL TESTS PASSED!');

--- a/test_game.mjs
+++ b/test_game.mjs
@@ -157,6 +157,78 @@ console.log('\nBoss kill crediting');
   assert(g.floatingTexts.some(t => t.text === g.ENEMY_TYPES.clippy.deathMsg), 'clippy death message shown');
 }
 
+// ---- Cane arc reaches what it looks like it reaches ----
+console.log('\nCane hitbox');
+{
+  // Swing, then resolve the cane directly so collision doesn't confuse things.
+  const probe = (dx, dy, setup) => {
+    const g = fresh();
+    g.health = 999;
+    g.player.x = 400; g.player.y = 300; g.player.facing = 1;
+    g.enemies = [];
+    if (setup) setup(g);
+    g.spawnEnemyAt('jsBlob', 400 + dx, 300 + dy);
+    const target = g.enemies[g.enemies.length - 1];
+    target.hp = 999;
+    g.swingCane();
+    g.checkCaneHit();
+    return { hit: target.hp < 999, facing: g.player.facing };
+  };
+
+  assert(probe(0, 0).hit, 'an enemy standing on top of the player is hit');
+  assert(probe(12, 0).hit, 'an enemy in the old dead zone (12px ahead) is hit');
+  assert(probe(-45, 0).hit, 'an enemy behind the player is hit');
+  assert(probe(-45, 0).facing === -1, 'swinging turns you toward a target behind you');
+  assert(probe(45, 0).facing === 1, 'a target in front does not flip your facing');
+  assert(probe(0, -50).hit, 'an enemy directly above is hit');
+  assert(!probe(200, 0).hit, 'an enemy well out of reach is still a miss');
+
+  // The nearest target decides the flip, not just any target.
+  const both = probe(-40, 0, g => g.spawnEnemyAt('jsBlob', 400 + 20, 300));
+  assert(both.facing === 1, 'a closer target in front keeps you facing forward');
+
+  // The new arc must strictly contain the old circle: nobody loses a poke.
+  const oldHit = (dx, dy) => Math.hypot(dx - 40, dy) < 30;
+  let lost = 0;
+  for (let dx = -100; dx <= 100; dx += 10) {
+    for (let dy = -100; dy <= 100; dy += 10) {
+      if (oldHit(dx, dy) && !probe(dx, dy).hit) lost++;
+    }
+  }
+  assert(lost === 0, `new arc covers everything the old hitbox did (lost ${lost} cells)`);
+}
+
+// ---- Swing stays live for more than one frame ----
+console.log('\nSwing window');
+{
+  let slipped = 0;
+  for (let offset = 0; offset < 14; offset++) {
+    const g = fresh();
+    g.health = 999;
+    g.player.x = 400; g.player.y = 300; g.player.facing = 1;
+    g.enemies = [];
+    g.spawnEnemyAt('dansFix', 500, 300);   // speed 3, closing fast
+    g.enemies[0].hp = 999;
+    tick(g, offset);
+    g.swingCane();
+    tick(g, 13);
+    if (g.enemies[0] && g.enemies[0].hp === 999) slipped++;
+  }
+  assert(slipped <= 3, `a fast enemy rarely crosses the arc unhit (${slipped}/14 timings)`);
+}
+
+// ---- Combat is actually winnable ----
+console.log('\nCombat throughput');
+{
+  const g = loadGame();
+  g.startGame();
+  g.health = 999;
+  g.wave = 1;
+  for (let i = 0; i < 1800; i++) { g.swingCane(); g.update(); }
+  const kills = Object.values(g.killLog).reduce((a, b) => a + b, 0);
+  assert(kills >= 12, `60s of wave 1 mashing SMACK lands a decent number of kills (${kills})`);
+}
+
 // ---- Health never goes negative, gameOver fires once ----
 console.log('\nDeath handling');
 {


### PR DESCRIPTION
Two bugs reported from playing the live build on mobile.

## "When I go left, the top of my head floats right"

`drawPixelChar` mirrored the character by negating individual x offsets:

```js
ctx.fillRect(-10 * facing, -18, 20, 6);   // hair
...
ctx.fillRect(-8, -14, 16, 14);            // head — no facing term at all
```

Negating an offset moves a rect's *anchor* but doesn't mirror it — the rect still extends rightward from that anchor. Facing left, the 20px-wide hair block anchored at `+10` and drew from x=10 to x=30, well clear of the head. The at-rest cane was mis-mirrored the same way.

Replaced with a single `ctx.scale(facing, 1)` and canonical right-facing coordinates throughout, so the sprite mirrors as one piece.

| Before | After |
|---|---|
| Hair detached, floating up-and-right; cane on the wrong side | Proper mirror in both directions |

## "I'm swinging and swinging and not hitting anything"

The hit test was a circle centred **40px in front** of the player with radius 30 — covering 10–70px ahead, and leaving a dead zone over the player's own body. That's exactly where enemies end up, because every enemy homes straight in on you. Being surrounded meant swinging through everything and landing nothing.

It was also evaluated on a **single frame** (`caneTimer === 6`) — a 16ms window at 60fps, so a Dan's Fix at speed 3 could cross the whole arc between checks.

Coverage map, player at `dx=0` facing right (`#` = hit before and after, `+` = newly hittable, `.` = miss):

```
        87654321012345678
dy=-40 |...+++++++++++...|
dy=-20 |..++++++++#####..|
dy=  0 |.+++++++++#####+.|      <- the old box never touched the player
dy= 20 |..++++++++#####+.|
dy= 40 |...++++++++++++..|

coverage cells: both 177, newly hittable 812, lost 0
```

Replaced with an arc measured from the player: a forward half-disc of radius 72 (92 in rage), plus a 30px bubble centred on the player that connects regardless of facing. **72/92 was picked so the new area strictly contains the old circle** — no poke that used to land now misses. The swing is live for frames 4–9 instead of one, with `enemy.hit` still preventing double-hits within a swing. Knockback now pushes away from the player rather than from a point 40px ahead.

Added a melee assist: swinging turns you toward the nearest target in reach **if it's behind you**. On touch, facing only changes when the stick is pushed sideways, so being chased from behind while walking upward was unwinnable. A nearer target in front never triggers a flip.

The arc is now drawn while it's live, so the hitbox is legible instead of something you infer from dying.

### Measured effect

60 seconds of wave 1 mashing SMACK, identical scripted input:

| | kills |
|---|---|
| currently live | 4 |
| with this fix | 21 |

## Tests

`node test_fixes.mjs` → 97 passed · `node test_game.mjs` → 66 passed · `test_fixes.html` → 32 passed

New coverage includes a generated coverage-map assertion that the new arc contains the old hitbox with zero lost cells, plus hitting an enemy on top of you / behind you / directly above, the facing-flip rules in both directions, the multi-frame window against a fast enemy at 14 phase offsets, and overall combat throughput. Static checks that the sprite mirrors via `ctx.scale` and that no per-part facing multipliers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LFi9i4Z2ZygCitDV6JpuK)_